### PR TITLE
Fix event observer for product wishlist remove

### DIFF
--- a/Observer/Event/WishlistRemoveProduct.php
+++ b/Observer/Event/WishlistRemoveProduct.php
@@ -110,7 +110,7 @@ class WishlistRemoveProduct implements ObserverInterface
             $customEventRequest = $this->wishlistRemove->prepareRequest(
                 self::EVENT,
                 $wishlist,
-                $observer->getEvent()->getProduct()
+                $observer->getEvent()->getItem()->getProduct()
             );
 
             if ($config->isEventMessageQueueEnabled(self::EVENT)) {


### PR DESCRIPTION
A TypeError occurs in the Synerise\Integration\SyneriseApi\Mapper\Event\WishlistRemove::prepareRequest() method due to a null value being passed as the $product argument. When a product is deleted from the wishlist, the Event object does not contain direct data about the product. Instead, the event provides a Magento\Wishlist\Model\Item object, which contains a reference to the associated product. By referencing the Item object in the event, the product is correctly retrieved, preventing the TypeError.

Error message: .CRITICAL: TypeError: Synerise\Integration\SyneriseApi\Mapper\Event\WishlistRemove::prepareRequest(): Argument #3 ($product) must be of type Magento\Catalog\Model\Product, null given